### PR TITLE
Disable clang-format for javascript files

### DIFF
--- a/js/.clang-format
+++ b/js/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true


### PR DESCRIPTION
These are linted when copying into skin directory by eslint.